### PR TITLE
feat: add support for future feature that will add recent tag interval selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idling.app",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "engines": {
     "node": "20.x"

--- a/src/app/components/empty/Empty.tsx
+++ b/src/app/components/empty/Empty.tsx
@@ -1,11 +1,15 @@
 import './Empty.css';
 
-export default function Empty() {
+export default function Empty({ label = '' }: { label: string }) {
   return (
     <div className="empty">
       <p>
-        No posts to show
-        <br />
+        {label && (
+          <>
+            {label}
+            <br />
+          </>
+        )}
         ＞︿＜
       </p>
     </div>

--- a/src/app/components/recent-tags/RecentTags.tsx
+++ b/src/app/components/recent-tags/RecentTags.tsx
@@ -15,7 +15,7 @@ export async function RecentTags() {
         <FancyBorder>
           <h4>Recent Tags (3 months)</h4>
 
-          {recentTags.tags && (
+          {recentTags.tags.length > 0 && (
             <ol className="recent-tags__list">
               {recentTags.tags.map((tag) => {
                 return (
@@ -27,7 +27,7 @@ export async function RecentTags() {
             </ol>
           )}
 
-          {!recentTags.tags && <Empty />}
+          {!recentTags.tags.length && <Empty label="No recent tags" />}
         </FancyBorder>
       </Card>
     </article>

--- a/src/app/components/submissions-list/SubmissionsList.tsx
+++ b/src/app/components/submissions-list/SubmissionsList.tsx
@@ -62,7 +62,7 @@ export default async function SubmissionsList({
 
   return (
     <ol className="submission__list">
-      {!submissions.length && <Empty />}
+      {!submissions.length && <Empty label="No posts to show" />}
 
       {!!submissions.length &&
         submissions.map(


### PR DESCRIPTION
- 'hrs', 'days', or 'months' will be available
- will always have a numerical counterpart of 3 for the interval i.e. `3 hrs`, `3 days`, `3 months`